### PR TITLE
Initialize web app skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/coverletter"
+OPENAI_API_KEY="your-openai-key"
+STRIPE_SECRET_KEY="your-stripe-secret"
+STRIPE_WEBHOOK_SECRET="whsec_xxx"
+NEXTAUTH_URL="http://localhost:3000"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+node_modules
+.next
+.env
+.env.local
+
+# macOS
+.DS_Store
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Prisma
+prisma/dev.db
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# cover-letter-codex
+# Cover Letter Codex
+
+A web application to generate personalized cover letters based on a user's CV and a specific job offer.
+
+## Features
+- Upload CVs and extract summaries using OCR if needed.
+- Upload or scan job offers to extract requirements.
+- Short questionnaire to tailor motivation.
+- Generate letters in multiple languages using OpenAI GPT.
+- User review and feedback system.
+- Profile photos and multilingual interface.
+- Subscription plans with usage quotas via Stripe.
+
+## Tech Stack
+- **Next.js** + **React** + **Tailwind CSS** + **TypeScript**
+- **PostgreSQL** + **Prisma ORM**
+- **OpenAI GPT** for text generation
+- **next-i18next** for i18n
+- **next-auth** (placeholder) for authentication
+- **Stripe** for payments
+- **Tesseract.js** for OCR parsing
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Copy `.env.example` to `.env` and fill in the required variables.
+3. Run database migrations:
+   ```bash
+   npx prisma migrate dev --name init
+   ```
+4. Start the dev server:
+   ```bash
+   npm run dev
+   ```
+
+## Environment Variables
+See `.env.example` for all necessary environment variables such as database URL, OpenAI key, and Stripe keys.
+
+## Prisma
+Prisma schema is located in `prisma/schema.prisma`. Adjust models as needed and run migrations.
+
+## License
+MIT

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr', 'es'],
+  },
+};

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+import { i18n } from './next-i18next.config.js';
+
+const nextConfig = {
+  reactStrictMode: true,
+  i18n,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "cover-letter-codex",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "typescript": "^5.2.2",
+    "tailwindcss": "latest",
+    "postcss": "latest",
+    "autoprefixer": "latest",
+    "@prisma/client": "latest",
+    "prisma": "latest",
+    "next-i18next": "latest",
+    "tesseract.js": "latest",
+    "openai": "latest",
+    "stripe": "latest",
+    "next-auth": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest",
+    "@types/react": "latest",
+    "@types/react-dom": "latest"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,69 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id             String   @id @default(uuid())
+  email          String   @unique
+  password       String
+  name           String?
+  profilePhoto   String?
+  cvSummaries    CVSummary[]
+  jobOffers      JobOffer[]
+  letters        GeneratedLetter[]
+  subscription   Subscription?
+  feedbacks      Feedback[]
+  createdAt      DateTime @default(now())
+}
+
+model CVSummary {
+  id       String   @id @default(uuid())
+  content  String
+  user     User     @relation(fields: [userId], references: [id])
+  userId   String
+  createdAt DateTime @default(now())
+}
+
+model JobOffer {
+  id       String   @id @default(uuid())
+  content  String
+  user     User     @relation(fields: [userId], references: [id])
+  userId   String
+  createdAt DateTime @default(now())
+}
+
+model GeneratedLetter {
+  id       String   @id @default(uuid())
+  content  String
+  language String
+  user     User     @relation(fields: [userId], references: [id])
+  userId   String
+  createdAt DateTime @default(now())
+}
+
+model Subscription {
+  id            String   @id @default(uuid())
+  user          User     @relation(fields: [userId], references: [id])
+  userId        String   @unique
+  plan          String
+  lettersQuota  Int
+  lettersUsed   Int       @default(0)
+  stripeSubId   String?
+  renewedAt     DateTime?
+}
+
+model Feedback {
+  id         String   @id @default(uuid())
+  rating     Int
+  comment    String?
+  letter     GeneratedLetter @relation(fields: [letterId], references: [id])
+  letterId   String
+  user       User            @relation(fields: [userId], references: [id])
+  userId     String
+  createdAt  DateTime @default(now())
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,17 @@
+import { prisma } from '../src/lib/prisma';
+
+async function main() {
+  // Seed demo user
+  await prisma.user.create({
+    data: {
+      email: 'demo@example.com',
+      password: 'password',
+      name: 'Demo User',
+    },
+  });
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,0 +1,5 @@
+{
+  "welcome": "Welcome to Cover Letter Codex",
+  "login": "Login",
+  "register": "Register"
+}

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,0 +1,5 @@
+{
+  "welcome": "Bienvenido a Cover Letter Codex",
+  "login": "Iniciar sesión",
+  "register": "Registrarse"
+}

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,0 +1,5 @@
+{
+  "welcome": "Bienvenue sur Cover Letter Codex",
+  "login": "Connexion",
+  "register": "Inscription"
+}

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -1,0 +1,6 @@
+import Tesseract from 'tesseract.js';
+
+export async function parseImage(file: File): Promise<string> {
+  const { data } = await Tesseract.recognize(file, 'eng');
+  return data.text;
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: ['query'],
+  });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: '2023-08-16',
+});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,9 @@
+import type { AppProps } from 'next/app';
+import { appWithTranslation } from 'next-i18next';
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default appWithTranslation(MyApp);

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,18 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+export default NextAuth({
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        // TODO: validate user
+        return { id: '1', email: credentials?.email } as any;
+      },
+    }),
+  ],
+});

--- a/src/pages/api/generate-letter.ts
+++ b/src/pages/api/generate-letter.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Configuration, OpenAIApi } from 'openai';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+
+  const { cvSummary, jobOffer, answers, language } = req.body as {
+    cvSummary: string;
+    jobOffer: string;
+    answers: string;
+    language: string;
+  };
+
+  const configuration = new Configuration({ apiKey: process.env.OPENAI_API_KEY });
+  const openai = new OpenAIApi(configuration);
+
+  try {
+    const completion = await openai.createChatCompletion({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: `Generate a cover letter in ${language}` },
+        { role: 'user', content: `CV: ${cvSummary}\nJob: ${jobOffer}\nAnswers: ${answers}` },
+      ],
+    });
+    const letter = completion.data.choices[0].message?.content;
+    res.status(200).json({ letter });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to generate letter' });
+  }
+}

--- a/src/pages/api/webhook.ts
+++ b/src/pages/api/webhook.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { stripe } from '../../lib/stripe';
+import { buffer } from 'micro';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const sig = req.headers['stripe-signature'] as string;
+  const buf = await buffer(req);
+
+  try {
+    stripe.webhooks.constructEvent(buf, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+  } catch (err) {
+    return res.status(400).send(`Webhook Error: ${(err as Error).message}`);
+  }
+
+  res.json({ received: true });
+}

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: integrate auth provider
+    router.push('/dashboard');
+  };
+
+  return (
+    <form className="max-w-md mx-auto p-4" onSubmit={handleLogin}>
+      <h1 className="text-xl mb-4">Login</h1>
+      <input
+        type="email"
+        placeholder="Email"
+        className="border p-2 w-full mb-2"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        className="border p-2 w-full mb-4"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Register() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: integrate auth provider
+    router.push('/dashboard');
+  };
+
+  return (
+    <form className="max-w-md mx-auto p-4" onSubmit={handleRegister}>
+      <h1 className="text-xl mb-4">Register</h1>
+      <input
+        type="email"
+        placeholder="Email"
+        className="border p-2 w-full mb-2"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        className="border p-2 w-full mb-4"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2">
+        Register
+      </button>
+    </form>
+  );
+}

--- a/src/pages/dashboard/generator.tsx
+++ b/src/pages/dashboard/generator.tsx
@@ -1,0 +1,8 @@
+export default function Generator() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Generate Letter</h1>
+      {/* TODO: letter generation form and results */}
+    </div>
+  );
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+
+export default function Dashboard() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/dashboard/upload-cv" className="underline">
+            Upload CV
+          </Link>
+        </li>
+        <li>
+          <Link href="/dashboard/upload-job" className="underline">
+            Upload Job Offer
+          </Link>
+        </li>
+        <li>
+          <Link href="/dashboard/questionnaire" className="underline">
+            Questionnaire
+          </Link>
+        </li>
+        <li>
+          <Link href="/dashboard/generator" className="underline">
+            Generate Letter
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/dashboard/questionnaire.tsx
+++ b/src/pages/dashboard/questionnaire.tsx
@@ -1,0 +1,8 @@
+export default function Questionnaire() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Questionnaire</h1>
+      {/* TODO: questionnaire form */}
+    </div>
+  );
+}

--- a/src/pages/dashboard/upload-cv.tsx
+++ b/src/pages/dashboard/upload-cv.tsx
@@ -1,0 +1,8 @@
+export default function UploadCV() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Upload CV</h1>
+      {/* TODO: CV upload component */}
+    </div>
+  );
+}

--- a/src/pages/dashboard/upload-job.tsx
+++ b/src/pages/dashboard/upload-job.tsx
@@ -1,0 +1,8 @@
+export default function UploadJob() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Upload Job Offer</h1>
+      {/* TODO: Job offer upload / scan component */}
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { useTranslation } from 'next-i18next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import type { GetStaticProps } from 'next';
+
+export default function Home() {
+  const { t } = useTranslation();
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold mb-4">{t('welcome')}</h1>
+      <nav className="space-x-4">
+        <Link href="/auth/login" className="underline">
+          {t('login')}
+        </Link>
+        <Link href="/auth/register" className="underline">
+          {t('register')}
+        </Link>
+      </nav>
+    </main>
+  );
+}
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale ?? 'en', ['common'])),
+  },
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "src/**/*", "next.config.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- start Next.js app with Tailwind and TypeScript
- add i18n setup and sample translations
- scaffold pages for auth, dashboard, and API routes
- define Prisma schema and seed script
- provide environment example and setup instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f0b2dbad8832589e2c33a5c97956b