### PR TITLE
Add back button and dynamic questionnaire

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "tesseract.js": "latest",
     "openai": "latest",
     "stripe": "latest",
-    "next-auth": "latest"
+    "next-auth": "latest",
+    "cheerio": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,16 @@
+import Link from 'next/link';
+
+/** Accessible back button used across all pages */
+export default function BackButton() {
+  return (
+    <Link
+      href="/"
+      aria-label="Back to home"
+      className="inline-flex items-center text-blue-600 hover:underline focus-visible:outline focus-visible:ring-2 focus-visible:ring-blue-500 mb-4"
+    >
+      {/* simple left arrow */}
+      <span aria-hidden="true" className="mr-1">&larr;</span>
+      <span>Back</span>
+    </Link>
+  );
+}

--- a/src/components/DynamicQuestionnaire.tsx
+++ b/src/components/DynamicQuestionnaire.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+
+interface Question {
+  id: string;
+  text: string;
+  options: string[];
+}
+
+const QUESTIONS: Question[] = [
+  {
+    id: 'motivation',
+    text: 'Quelles sont vos motivations principales pour ce poste ?',
+    options: [
+      'Évolution de carrière',
+      'Environnement stimulant',
+      'Meilleures conditions',
+    ],
+  },
+  {
+    id: 'experience',
+    text: "Quel est votre niveau d'expérience ?",
+    options: ['Junior', 'Intermédiaire', 'Senior'],
+  },
+  {
+    id: 'domain',
+    text: "Dans quel domaine d'activité travaillez-vous ?",
+    options: ['Informatique', 'Marketing', 'Finance', 'Autre'],
+  },
+  {
+    id: 'worklife',
+    text: 'Quelle est votre priorité pour la relation travail/vie privée ?',
+    options: ['Très équilibrée', 'Standard 9-5', "Heures supplémentaires possibles"],
+  },
+];
+
+export default function DynamicQuestionnaire() {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+
+  const handleSelect = (answer: string) => {
+    const q = QUESTIONS[step];
+    setAnswers((prev) => ({ ...prev, [q.id]: answer }));
+    setStep((s) => s + 1);
+  };
+
+  if (step >= QUESTIONS.length) {
+    return (
+      <div className="p-4">
+        <h2 className="text-xl font-semibold mb-2">Merci !</h2>
+        <pre className="whitespace-pre-wrap">{JSON.stringify(answers, null, 2)}</pre>
+      </div>
+    );
+  }
+
+  const question = QUESTIONS[step];
+
+  return (
+    <div
+      key={question.id}
+      className="p-4 transition-opacity duration-300 ease-in-out"
+    >
+      <h2 className="text-lg font-medium mb-4">{question.text}</h2>
+      <div className="space-y-2">
+        {question.options.map((opt) => (
+          <button
+            key={opt}
+            onClick={() => handleSelect(opt)}
+            className="block w-full text-left border px-4 py-2 rounded hover:bg-blue-50 focus-visible:outline focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            {opt}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4 text-sm text-gray-500">
+        Question {step + 1} / {QUESTIONS.length}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/api/parse-job.ts
+++ b/src/pages/api/parse-job.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as cheerio from 'cheerio';
+
+// Simple parser that fetches the HTML of a job offer URL and extracts
+// basic information (title, company, description).
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).end();
+  }
+  const { url } = req.body as { url: string };
+  if (!url) return res.status(400).json({ error: 'No URL provided' });
+
+  try {
+    const response = await fetch(url);
+    const html = await response.text();
+    const $ = cheerio.load(html);
+
+    const title = $('h1').first().text().trim() || $('title').text().trim();
+    const company =
+      $('meta[property="og:site_name"]').attr('content') || '';
+    const description =
+      $('meta[name="description"]').attr('content') || $('p').text();
+
+    res.status(200).json({ title, company, description });
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to fetch job offer' });
+  }
+}

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import BackButton from '../../components/BackButton';
 
 export default function Login() {
   const router = useRouter();
@@ -14,6 +15,7 @@ export default function Login() {
 
   return (
     <form className="max-w-md mx-auto p-4" onSubmit={handleLogin}>
+      <BackButton />
       <h1 className="text-xl mb-4">Login</h1>
       <input
         type="email"

--- a/src/pages/auth/register.tsx
+++ b/src/pages/auth/register.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useRouter } from 'next/router';
+import BackButton from '../../components/BackButton';
 
 export default function Register() {
   const router = useRouter();
@@ -14,6 +15,7 @@ export default function Register() {
 
   return (
     <form className="max-w-md mx-auto p-4" onSubmit={handleRegister}>
+      <BackButton />
       <h1 className="text-xl mb-4">Register</h1>
       <input
         type="email"

--- a/src/pages/dashboard/generator.tsx
+++ b/src/pages/dashboard/generator.tsx
@@ -1,8 +1,12 @@
 import { useState } from 'react';
+import BackButton from '../../components/BackButton';
 
 export default function Generator() {
   const [cvSummary, setCvSummary] = useState('');
   const [jobOffer, setJobOffer] = useState('');
+  const [jobUrl, setJobUrl] = useState('');
+  const [jobTitle, setJobTitle] = useState('');
+  const [company, setCompany] = useState('');
   const [answers, setAnswers] = useState('');
   const [language, setLanguage] = useState('en');
   const [letter, setLetter] = useState('');
@@ -12,7 +16,12 @@ export default function Generator() {
     const res = await fetch('/api/generate-letter', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cvSummary, jobOffer, answers, language }),
+      body: JSON.stringify({
+        cvSummary,
+        jobOffer: `${jobTitle} ${company}\n${jobOffer}`,
+        answers,
+        language,
+      }),
     });
     const data = await res.json();
     setLetter(data.letter || data.error || 'Failed to generate');
@@ -20,8 +29,50 @@ export default function Generator() {
 
   return (
     <div className="p-4">
+      <BackButton />
       <h1 className="text-xl font-bold mb-4">Generate Letter</h1>
       <form className="space-y-4" onSubmit={handleGenerate}>
+        <input
+          className="border p-2 w-full"
+          placeholder="Job offer URL"
+          value={jobUrl}
+          onChange={(e) => setJobUrl(e.target.value)}
+          onBlur={async () => {
+            if (!jobUrl) return;
+            const res = await fetch('/api/parse-job', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ url: jobUrl }),
+            });
+            const data = await res.json();
+            if (data.title) setJobTitle(data.title);
+            if (data.company) setCompany(data.company);
+            if (data.description) setJobOffer((prev) => data.description + '\n' + prev);
+          }}
+        />
+        <input
+          type="file"
+          accept=".pdf,.doc,.docx"
+          className="border p-2 w-full"
+          onChange={async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            const text = await file.text();
+            setJobOffer((prev) => prev + '\n' + text);
+          }}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Job title"
+          value={jobTitle}
+          onChange={(e) => setJobTitle(e.target.value)}
+        />
+        <input
+          className="border p-2 w-full"
+          placeholder="Company"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+        />
         <textarea
           className="border p-2 w-full"
           rows={4}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
+import BackButton from '../../components/BackButton';
 
 export default function Dashboard() {
   return (
     <div className="p-4">
+      <BackButton />
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
       <ul className="space-y-2">
         <li>

--- a/src/pages/dashboard/questionnaire.tsx
+++ b/src/pages/dashboard/questionnaire.tsx
@@ -1,34 +1,12 @@
-import { useState } from 'react';
+import BackButton from '../../components/BackButton';
+import DynamicQuestionnaire from '../../components/DynamicQuestionnaire';
 
 export default function Questionnaire() {
-  const [motivation, setMotivation] = useState('');
-  const [skills, setSkills] = useState('');
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    alert('Answers saved');
-  };
-
   return (
-    <form className="p-4 space-y-4" onSubmit={handleSubmit}>
+    <div className="p-4">
+      <BackButton />
       <h1 className="text-xl font-bold mb-4">Questionnaire</h1>
-      <textarea
-        className="border p-2 w-full"
-        rows={3}
-        placeholder="Why do you want this job?"
-        value={motivation}
-        onChange={(e) => setMotivation(e.target.value)}
-      />
-      <textarea
-        className="border p-2 w-full"
-        rows={3}
-        placeholder="What skills make you a good fit?"
-        value={skills}
-        onChange={(e) => setSkills(e.target.value)}
-      />
-      <button className="bg-blue-500 text-white px-4 py-2" type="submit">
-        Save
-      </button>
-    </form>
+      <DynamicQuestionnaire />
+    </div>
   );
 }

--- a/src/pages/dashboard/upload-cv.tsx
+++ b/src/pages/dashboard/upload-cv.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { parseImage } from '../../lib/ocr';
+import BackButton from '../../components/BackButton';
 
 export default function UploadCV() {
   const [text, setText] = useState('');
@@ -13,6 +14,7 @@ export default function UploadCV() {
 
   return (
     <div className="p-4">
+      <BackButton />
       <h1 className="text-xl font-bold mb-4">Upload CV</h1>
       <input
         type="file"

--- a/src/pages/dashboard/upload-job.tsx
+++ b/src/pages/dashboard/upload-job.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { parseImage } from '../../lib/ocr';
+import BackButton from '../../components/BackButton';
 
 export default function UploadJob() {
   const [text, setText] = useState('');
@@ -13,6 +14,7 @@ export default function UploadJob() {
 
   return (
     <div className="p-4">
+      <BackButton />
       <h1 className="text-xl font-bold mb-4">Upload Job Offer</h1>
       <input
         type="file"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,13 @@ import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import type { GetStaticProps } from 'next';
+import BackButton from '../components/BackButton';
 
 export default function Home() {
   const { t } = useTranslation();
   return (
     <main className="p-4">
+      <BackButton />
       <h1 className="text-2xl font-bold mb-4">{t('welcome')}</h1>
       <nav className="space-x-4">
         <Link href="/auth/login" className="underline">


### PR DESCRIPTION
## Summary
- add reusable `<BackButton>` component and integrate on all pages
- implement dynamic questionnaire flow
- enhance letter generator with job offer URL parsing and file upload
- add API route `parse-job` using cheerio
- include cheerio dependency

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4efda6c08325870d8bbda780e6f6