### PR TITLE
Implement Supabase storage uploads with OCR

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@supabase/supabase-js": "latest",
     "next-i18next": "latest",
     "tesseract.js": "latest",
+    "@supabase/storage-js": "latest",
+    "mammoth": "latest",
     "openai": "latest",
     "stripe": "latest",
     "next-auth": "latest"

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -1,6 +1,14 @@
 import Tesseract from 'tesseract.js';
 
-export async function parseImage(file: File): Promise<string> {
+export async function parseDocument(file: File): Promise<string> {
+  if (file.type ===
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    const mammoth = await import('mammoth');
+    const arrayBuffer = await file.arrayBuffer();
+    const { value } = await mammoth.default.extractRawText({ arrayBuffer });
+    return value;
+  }
+
   const { data } = await Tesseract.recognize(file, 'eng');
   return data.text;
 }

--- a/src/lib/storageClient.ts
+++ b/src/lib/storageClient.ts
@@ -1,0 +1,9 @@
+import { StorageClient } from '@supabase/storage-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL as string;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY as string;
+
+export const storage = new StorageClient(`${supabaseUrl}/storage/v1`, {
+  apikey: supabaseAnonKey,
+  Authorization: `Bearer ${supabaseAnonKey}`,
+});

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.SUPABASE_URL as string;
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY as string;
+const supabaseUrl = (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL) as string;
+const supabaseAnonKey = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY) as string;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});

--- a/src/pages/dashboard/upload-cv.tsx
+++ b/src/pages/dashboard/upload-cv.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
-import { parseImage } from '../../lib/ocr';
+import { parseDocument } from '../../lib/ocr';
+import { storage } from '../../lib/storageClient';
+import { supabase } from '../../lib/supabaseClient';
 
 export default function UploadCV() {
   const [text, setText] = useState('');
@@ -7,7 +9,13 @@ export default function UploadCV() {
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    const parsed = await parseImage(file);
+    const path = `cv/${Date.now()}_${file.name}`;
+    const { error: uploadError } = await storage.from('documents').upload(path, file);
+    if (uploadError) {
+      console.error(uploadError);
+    }
+    const parsed = await parseDocument(file);
+    await supabase.from('documents').insert({ path, text: parsed, type: 'cv' });
     setText(parsed);
   };
 
@@ -16,7 +24,7 @@ export default function UploadCV() {
       <h1 className="text-xl font-bold mb-4">Upload CV</h1>
       <input
         type="file"
-        accept="image/*,.pdf"
+        accept=".pdf,.docx"
         onChange={handleFile}
         className="mb-4"
       />


### PR DESCRIPTION
## Summary
- add `@supabase/storage-js` and `mammoth` dependencies
- parse PDF/DOCX files with OCR or mammoth
- add storage client for direct uploads
- store uploaded files and extracted text in Supabase
- support authenticated Supabase client configuration

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f53a0db088325b14a94cf70c6af14