### PR TITLE
Add universal dashboard layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "openai": "latest",
     "stripe": "latest",
     "next-auth": "latest",
-    "bcryptjs": "latest"
+    "bcryptjs": "latest",
+    "@heroicons/react": "latest"
   },
   "devDependencies": {
     "@types/node": "latest",

--- a/src/components/ActivityList.tsx
+++ b/src/components/ActivityList.tsx
@@ -1,0 +1,23 @@
+export interface ActivityItem {
+  id: number;
+  text: string;
+}
+
+interface ActivityListProps {
+  items: ActivityItem[];
+}
+
+export default function ActivityList({ items }: ActivityListProps) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="font-semibold mb-2">Recent Activity</h3>
+      <ul className="text-sm space-y-1">
+        {items.map((item) => (
+          <li key={item.id} className="text-gray-600">
+            {item.text}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/BalanceCard.tsx
+++ b/src/components/BalanceCard.tsx
@@ -1,0 +1,12 @@
+interface BalanceCardProps {
+  remaining: number;
+}
+
+export default function BalanceCard({ remaining }: BalanceCardProps) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <p className="text-sm text-gray-500">Remaining Credits</p>
+      <p className="text-2xl font-bold text-violet-600">{remaining}</p>
+    </div>
+  );
+}

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+import Sidebar from './Sidebar';
+import BalanceCard from './BalanceCard';
+import ActivityList, { ActivityItem } from './ActivityList';
+import TopCategories from './TopCategories';
+
+interface MainLayoutProps {
+  children?: ReactNode;
+}
+
+export default function MainLayout({ children }: MainLayoutProps) {
+  const activities: ActivityItem[] = [
+    { id: 1, text: 'Generated a letter' },
+    { id: 2, text: 'Updated profile information' },
+  ];
+
+  const categories = [
+    { id: 1, name: 'Technology' },
+    { id: 2, name: 'Marketing' },
+    { id: 3, name: 'Finance' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <Sidebar />
+      <div className="flex-1 flex flex-col lg:flex-row">
+        <main className="flex-1 p-4">
+          {children || <p className="text-gray-600">Welcome</p>}
+        </main>
+        <aside className="w-full lg:w-80 p-4 space-y-4">
+          <BalanceCard remaining={3} />
+          <ActivityList items={activities} />
+          <TopCategories categories={categories} />
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import Sidebar from './Sidebar';
 import BalanceCard from './BalanceCard';
 import ActivityList, { ActivityItem } from './ActivityList';
@@ -9,6 +9,8 @@ interface MainLayoutProps {
 }
 
 export default function MainLayout({ children }: MainLayoutProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   const activities: ActivityItem[] = [
     { id: 1, text: 'Generated a letter' },
     { id: 2, text: 'Updated profile information' },
@@ -22,8 +24,26 @@ export default function MainLayout({ children }: MainLayoutProps) {
 
   return (
     <div className="min-h-screen bg-gray-50 flex">
-      <Sidebar />
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
       <div className="flex-1 flex flex-col lg:flex-row">
+        <header className="sm:hidden p-2 border-b flex items-center">
+          <button onClick={() => setSidebarOpen(true)} aria-label="Open menu">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5"
+              />
+            </svg>
+          </button>
+        </header>
         <main className="flex-1 p-4">
           {children || <p className="text-gray-600">Welcome</p>}
         </main>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,11 @@
 import Link from 'next/link';
-import { HomeIcon, UserIcon, Squares2X2Icon } from '@heroicons/react/24/outline';
+import {
+  HomeIcon,
+  UserIcon,
+  Squares2X2Icon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
+import { Fragment } from 'react';
 
 const navItems = [
   { href: '/', label: 'Home', icon: HomeIcon },
@@ -7,18 +13,37 @@ const navItems = [
   { href: '/profile', label: 'Profile', icon: UserIcon },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
   return (
-    <aside className="hidden sm:flex sm:flex-col w-64 bg-white shadow h-screen sticky top-0">
-      <div className="p-4 font-bold text-xl">Codex</div>
-      <nav className="flex-1 p-4 space-y-2">
-        {navItems.map(({ href, label, icon: Icon }) => (
-          <Link key={href} href={href} className="flex items-center space-x-2 p-2 rounded hover:bg-violet-50">
-            <Icon className="h-5 w-5" />
-            <span>{label}</span>
-          </Link>
-        ))}
-      </nav>
-    </aside>
+    <Fragment>
+      {/* Overlay */}
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity sm:hidden ${open ? '' : 'hidden'}`}
+      />
+      <aside
+        className={`fixed inset-y-0 left-0 z-50 w-64 bg-white shadow transform transition-transform sm:static sm:translate-x-0 sm:flex sm:flex-col ${open ? 'translate-x-0' : '-translate-x-full'}`}
+      >
+        <div className="flex items-center justify-between p-4 border-b sm:justify-center">
+          <span className="font-bold text-xl">Codex</span>
+          <button className="sm:hidden" onClick={onClose} aria-label="Close sidebar">
+            <XMarkIcon className="h-6 w-6" />
+          </button>
+        </div>
+        <nav className="flex-1 p-4 space-y-2">
+          {navItems.map(({ href, label, icon: Icon }) => (
+            <Link key={href} href={href} className="flex items-center space-x-2 p-2 rounded hover:bg-violet-50">
+              <Icon className="h-5 w-5" />
+              <span>{label}</span>
+            </Link>
+          ))}
+        </nav>
+      </aside>
+    </Fragment>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { HomeIcon, UserIcon, Squares2X2Icon } from '@heroicons/react/24/outline';
+
+const navItems = [
+  { href: '/', label: 'Home', icon: HomeIcon },
+  { href: '/dashboard', label: 'Dashboard', icon: Squares2X2Icon },
+  { href: '/profile', label: 'Profile', icon: UserIcon },
+];
+
+export default function Sidebar() {
+  return (
+    <aside className="hidden sm:flex sm:flex-col w-64 bg-white shadow h-screen sticky top-0">
+      <div className="p-4 font-bold text-xl">Codex</div>
+      <nav className="flex-1 p-4 space-y-2">
+        {navItems.map(({ href, label, icon: Icon }) => (
+          <Link key={href} href={href} className="flex items-center space-x-2 p-2 rounded hover:bg-violet-50">
+            <Icon className="h-5 w-5" />
+            <span>{label}</span>
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,13 @@
+interface StatCardProps {
+  title: string;
+  value: string | number;
+}
+
+export default function StatCard({ title, value }: StatCardProps) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <p className="text-sm text-gray-500">{title}</p>
+      <p className="text-xl font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/src/components/TopCategories.tsx
+++ b/src/components/TopCategories.tsx
@@ -1,0 +1,23 @@
+interface Category {
+  id: number;
+  name: string;
+}
+
+interface TopCategoriesProps {
+  categories: Category[];
+}
+
+export default function TopCategories({ categories }: TopCategoriesProps) {
+  return (
+    <div className="bg-white shadow rounded p-4">
+      <h3 className="font-semibold mb-2">Top Categories</h3>
+      <ul className="text-sm space-y-1">
+        {categories.map((c) => (
+          <li key={c.id} className="text-gray-600">
+            {c.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,23 @@
+import type { ReactElement, ReactNode } from 'react';
 import type { AppProps } from 'next/app';
+import type { NextPage } from 'next';
 import { appWithTranslation } from 'next-i18next';
 import { SessionProvider } from 'next-auth/react';
 import '../styles/globals.css';
 
-function MyApp({ Component, pageProps }: AppProps) {
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode;
+};
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+};
+
+function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout ?? ((page) => page);
   return (
     <SessionProvider session={(pageProps as any).session}>
-      <Component {...pageProps} />
+      {getLayout(<Component {...pageProps} />)}
     </SessionProvider>
   );
 }

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -3,12 +3,14 @@ import { GetServerSidePropsContext } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../api/auth/[...nextauth]';
 import { supabase } from '../../lib/supabaseClient';
+import MainLayout from '../../components/MainLayout';
+import type { NextPageWithLayout } from '../_app';
 
 interface DashboardProps {
   generationCount: number;
 }
 
-export default function Dashboard({ generationCount }: DashboardProps) {
+const Dashboard: NextPageWithLayout<DashboardProps> = ({ generationCount }) => {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
@@ -37,7 +39,11 @@ export default function Dashboard({ generationCount }: DashboardProps) {
       </ul>
     </div>
   );
-}
+};
+
+Dashboard.getLayout = (page) => <MainLayout>{page}</MainLayout>;
+
+export default Dashboard;
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const session = await getServerSession(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,11 +2,13 @@ import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import type { GetStaticProps } from 'next';
+import MainLayout from '../components/MainLayout';
+import type { NextPageWithLayout } from './_app';
 
-export default function Home() {
+const Home: NextPageWithLayout = () => {
   const { t } = useTranslation();
   return (
-    <main className="p-4">
+    <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">{t('welcome')}</h1>
       <nav className="space-x-4">
         <Link href="/auth/login" className="underline">
@@ -16,9 +18,13 @@ export default function Home() {
           {t('register')}
         </Link>
       </nav>
-    </main>
+    </div>
   );
-}
+};
+
+Home.getLayout = (page) => <MainLayout>{page}</MainLayout>;
+
+export default Home;
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,0 +1,15 @@
+import type { NextPageWithLayout } from './_app';
+import MainLayout from '../components/MainLayout';
+
+const Profile: NextPageWithLayout = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Profile</h1>
+      <p className="text-gray-600">User profile information goes here.</p>
+    </div>
+  );
+};
+
+Profile.getLayout = (page) => <MainLayout>{page}</MainLayout>;
+
+export default Profile;


### PR DESCRIPTION
## Summary
- add reusable `MainLayout` with sidebar and right column cards
- create new components: `Sidebar`, `BalanceCard`, `ActivityList`, `TopCategories`, `StatCard`
- enable per-page layouts in `_app`
- apply layout to home, dashboard and new profile page
- include `@heroicons/react` in dependencies

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f77db0ec8832585b0379ffa33f6c4